### PR TITLE
feat: add exit command and handle EOF (Ctrl+D)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ Commands:
 - `!api` - Change API key
 - `!help` - Show help
 - `!cmd` - Run cmd directly
+- `exit` - Exit nlsh
 - `Ctrl+D` - Exit

--- a/nlsh.py
+++ b/nlsh.py
@@ -42,6 +42,7 @@ def show_help():
     print("\033[36m!uninstall\033[0m - Remove nlsh")
     print("\033[36m!help\033[0m      - Show this help")
     print("\033[36m!cmd\033[0m       - Run cmd directly")
+    print("\033[36mexit\033[0m       - Exit nlsh")
     print()
 
 load_env()
@@ -168,6 +169,9 @@ def main():
             if user_input == "!help":
                 show_help()
                 continue
+
+            if user_input in ["exit", "quit", "!exit"]:
+                sys.exit(0)
             
             if user_input.startswith("!"):
                 cmd = user_input[1:]
@@ -205,8 +209,10 @@ def main():
                         print(result.stderr, end="")
                     add_to_history(command, result.stdout + result.stderr)
             
-        except (EOFError, InterruptedError, KeyboardInterrupt):
+        except (InterruptedError, KeyboardInterrupt):
             continue
+        except EOFError:
+            sys.exit(0)
         except Exception as e:
             err = str(e)
             if "429" in err or "quota" in err.lower():


### PR DESCRIPTION
Currently, nlsh traps the user in the shell because typing exit only closes the internal subprocess, and Ctrl+D is explicitly caught and ignored. This PR adds explicit handlers to allow users to leave the shell gracefully.

**Changes**

- Added exit commands: Typing exit, quit, or !exit now terminates the program.

- Fixed EOF handling: Pressing Ctrl+D on an empty line now correctly exits the shell instead of continuing the loop.

- Updated help menu: Added the exit command to the output of !help.

- Updated documentation: Added exit to the commands list in README.md.


**Testing**

- Tested exit and quit commands manually.

- Verified that Ctrl+D (EOF) exits the application as expected.

- Verified that !help displays the new command